### PR TITLE
Steer gain changes (again)

### DIFF
--- a/BoosterGuidance.csproj
+++ b/BoosterGuidance.csproj
@@ -136,6 +136,7 @@
     <None Include="GameData\BoosterGuidance\BoosterGuidanceIcon.png" />
     <None Include="LICENSE" />
     <None Include="GameData\BoosterGuidance\BoosterGuidance.cfg" />
+    <None Include="CHANGES" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,44 @@
+v1.1.0
+- Finally fixed steer gain calculation (perhaps) as several bugs discovered
+
+v1.0.4
+- Will now always use FerramAerospaceResearch for aerodynamic calculations if its available. FAR seems to predict higher drag so landing burn alt often way lower
+- Better calculation of lift which means vessels should steer in the correct direction in landing burn (mostly!)
+- Considers aerodynamic lift in re-entry burn so if this lasts to the thick atmosphere steering will reverse
+- Only sign of gain (steer direction), rather than value is calculated by aerodynamic lift vs thrust. This means that gains are more stable between different vessel, RO, FAR, etc... and leads to less over-steering. Steer gain is still best set to max angle of 1-5 degrees with FAR though (for a typical Falcon-9 with gridfins) otherwise over-steers
+- Will cutout engine in final landing burn if too much minimum thrust. Only occurs in RO. This is hit and miss due to the time to throttle down engine
+- Major re-factoring to use BoosterGuidanceCore (the vessel part) as a central class. Code is cleaner and more reliable and fewer bugs for load/save/switch vessel
+- Target error is reported in km when >100km
+- Bug fixes to show/hide prediction/target
+- Size of prediction/target on map reduced
+- Click through prevention for pick target when under window
+- Many minor bug fixes
+- Stores engine ignite delay with BoosterGuidanceCore
+- Enable/Disable Guidance added as an Action Group
+
+v1.0.3a
+- Removed ModuleManager from zip file (ModuleManager is required though to include the BoosterGuidance settings in saved craft's and games, so please ensure it is installed)
+
+v1.0.3
+- Improvements for controlling multiple vessels simultaneously
+- Lots of bug fixes when switching vessels, e.g. show correct target, use correct settings
+- Add settings module which means settings are saved (e.g. target, re-entry alt, etc...) with the vessel in saved games. Will even save enable/disable guidance and phase so quick saves continue with vessels still controlled
+- Advanced menu can show brief info about other controlled vessels
+- Bug fix to ensure target is updated for vessel
+- Added ModuleManager DLL as Command Modules are patched to add BoosterGuidanceVesselSettings module
+- Reports message to user when vessels go outside the 20km physics bubble and can no longer be controlled due to game limitation
+Other changes/bug fixes
+
+Fixes for navigation target bugs such as stickiness
+Fixes when setting target to another vessel
+Fix bug which randomly set target to below current position when it wasn't set (in fact it was set but was just switching vessels)
+Use extra thrust in landing burn when vessel is leaned over (previously calculated thrust assuming vertical which could lead to insufficient thrust and a crash)
+Target can be set anywhere on planet in Flight or Map modes
+
+v1.0.2
+- Major improvements to pick targets. You can now pick a target anywhere in the flight or map view!
+- Increased touchdown margin for safety as rockets were crashing into the ground
+- In landing burn compensates for leaned over rockets by using extra thrust
+- Can now set target to navigation waypoints (note that they are currently sticky and you can't edit the lat/lon/alt until waypoint is deactivated)
+- Landing on Mun better tested and works but sometimes timewarp seems to move vessel oddly and throw out predictions (very odd)
+- Can now edit lat/lon with arrow adjusters so you can now fly back multiple cores and ensure they don't land on each other!

--- a/KSP/BoosterGuidanceCore.cs
+++ b/KSP/BoosterGuidanceCore.cs
@@ -68,6 +68,9 @@ namespace BoosterGuidance
     [KSPField(isPersistant = true, guiActive = false)]
     public string phase = "Unset";
 
+    [KSPField(isPersistant = true, guiActive = false)]
+    public float aeroMult = 1;
+
     public bool logging = false;
     public bool useFAR = false;
     public string logFilename = "unset";
@@ -126,7 +129,7 @@ namespace BoosterGuidance
       other.deployLandingGear = deployLandingGear;
       other.deployLandingGearHeight = deployLandingGearHeight;
       // can't sensibly clone this to other cores as once staged they will have different sets of engines
-      other.landingBurnEngines = "current";
+      other.landingBurnEngines = landingBurnEngines;
       other.landingBurnMaxAoA = landingBurnMaxAoA;
       other.landingBurnSteerKp = landingBurnSteerKp;
       other.reentryBurnAlt = reentryBurnAlt;
@@ -190,6 +193,7 @@ namespace BoosterGuidance
 
     public string UnsetLandingBurnEngines()
     {
+      Debug.Log("[BoosterGuidance] UnsetLandingBurnEngines");
       landingBurnEngines = "current";
       if (controller != null)
         controller.SetLandingBurnEnginesFromString(landingBurnEngines);
@@ -223,6 +227,7 @@ namespace BoosterGuidance
         controller.deployLandingGear = deployLandingGear;
         controller.deployLandingGearHeight = deployLandingGearHeight;
         controller.igniteDelay = igniteDelay;
+        controller.aeroMult = aeroMult;
         controller.SetLandingBurnEnginesFromString(landingBurnEngines);
       }
       CopyToOtherCores();

--- a/KSP/BoosterGuidanceCore.cs
+++ b/KSP/BoosterGuidanceCore.cs
@@ -167,16 +167,33 @@ namespace BoosterGuidance
 
     public string SetLandingBurnEngines()
     {
-      controller.SetLandingBurnEngines();
-      landingBurnEngines = controller.GetLandingBurnEngineString();
-      return controller.landingBurnEngines.Count().ToString();
+      List<ModuleEngines> activeEngines = KSPUtils.GetActiveEngines(vessel);
+      // get string
+      List<string> s = new List<string>();
+      int num = 0;
+      foreach(var engine in KSPUtils.GetAllEngines(vessel))
+      {
+        if (activeEngines.Contains(engine))
+        {
+          s.Add("1");
+          num++;
+        }
+        else
+          s.Add("0");
+      }
+      landingBurnEngines = String.Join(",", s.ToArray());
+      Debug.Log("[BoosterGuidance] landingBurnEngines=" + landingBurnEngines);
+      if (controller != null)
+        controller.SetLandingBurnEnginesFromString(landingBurnEngines);
+      return num.ToString();
     }
 
     public string UnsetLandingBurnEngines()
     {
-      controller.UnsetLandingBurnEngines();
-      landingBurnEngines = controller.GetLandingBurnEngineString();
-      return "current";
+      landingBurnEngines = "current";
+      if (controller != null)
+        controller.SetLandingBurnEnginesFromString(landingBurnEngines);
+      return landingBurnEngines;
     }
 
     public double LandingBurnHeight()
@@ -206,6 +223,7 @@ namespace BoosterGuidance
         controller.deployLandingGear = deployLandingGear;
         controller.deployLandingGearHeight = deployLandingGearHeight;
         controller.igniteDelay = igniteDelay;
+        controller.SetLandingBurnEnginesFromString(landingBurnEngines);
       }
       CopyToOtherCores();
     }
@@ -235,7 +253,6 @@ namespace BoosterGuidance
     public void EnableGuidance(KSPActionParam param)
     {
       controller = new BLController(vessel, useFAR);
-      controller.SetLandingBurnEnginesFromString(landingBurnEngines);
       Changed(); // updates controller
 
       if ((tgtLatitude == 0) && (tgtLongitude == 0) && (tgtAlt == 0))

--- a/KSP/BoosterGuidanceCore.cs
+++ b/KSP/BoosterGuidanceCore.cs
@@ -86,7 +86,6 @@ namespace BoosterGuidance
     {
       if (controller != null)
         DisableGuidance();
-      Debug.Log("[BoosterGuidance] BoosterGuidanceCore.OnDestroy()");
     }
 
     // Find first BoosterGuidanceCore module for vessel
@@ -125,10 +124,8 @@ namespace BoosterGuidance
 
     public void CopyToOtherCore(BoosterGuidanceCore other)
     {
-      //Debug.Log("[BoosterGuidance] CopyToOtherCore");
       other.deployLandingGear = deployLandingGear;
       other.deployLandingGearHeight = deployLandingGearHeight;
-      // can't sensibly clone this to other cores as once staged they will have different sets of engines
       other.landingBurnEngines = landingBurnEngines;
       other.landingBurnMaxAoA = landingBurnMaxAoA;
       other.landingBurnSteerKp = landingBurnSteerKp;
@@ -227,7 +224,6 @@ namespace BoosterGuidance
         controller.deployLandingGear = deployLandingGear;
         controller.deployLandingGearHeight = deployLandingGearHeight;
         controller.igniteDelay = igniteDelay;
-        controller.aeroMult = aeroMult;
         controller.SetLandingBurnEnginesFromString(landingBurnEngines);
       }
       CopyToOtherCores();
@@ -302,18 +298,13 @@ namespace BoosterGuidance
     [KSPAction("Disable BoosterGuidance")]
     public void DisableGuidance(KSPActionParam param)
     {
-      Debug.Log("[BoosterGuidance] Disabling Guidance");
       if (controller != null)
       {
-        Debug.Log("[BoosterGuidance] RemoveController");
         RemoveController(controller);
-        Debug.Log("[BoosterGuidance] stopLogging");
         controller.StopLogging();
-        Debug.Log("[BoosterGuidance] Disabled Guidance for vessel " + controller.vessel.name);
       }
       if ((vessel) && vessel.enabled) // extra checks
       {
-        Debug.Log("[BoosterGuidance] Removing FlyByWire");
         vessel.OnFlyByWire -= new FlightInputCallback(Fly);
         vessel.Autopilot.Disable();
       }

--- a/KSP/BoosterGuidanceCore.cs
+++ b/KSP/BoosterGuidanceCore.cs
@@ -97,7 +97,7 @@ namespace BoosterGuidance
         {
           if (mod.GetType() == typeof(BoosterGuidanceCore))
           {
-            Debug.Log("[BoosterGuidance] vessel=" + vessel.name + "part=" + part.name + " module=" + mod.name + " modtype=" + mod.GetType());
+            Debug.Log("[BoosterGuidance] vessel=" + vessel.name + " part=" + part.name + " module=" + mod.name + " modtype=" + mod.GetType());
             return (BoosterGuidanceCore)mod;
           }
         }

--- a/KSP/KSPUtils.cs
+++ b/KSP/KSPUtils.cs
@@ -52,6 +52,23 @@ namespace BoosterGuidance
       return activeEngines;
     }
 
+    public static void SetActiveEngines(Vessel vessel, List<ModuleEngines> active)
+    {
+      foreach(var engine in KSPUtils.GetAllEngines(vessel))
+      {
+        if (active.Contains(engine))
+        {
+          if (!engine.isOperational)
+            engine.Activate();
+        }
+        else
+        {
+          if (engine.isOperational)
+            engine.Shutdown();
+        }
+      }
+    }
+
     public static List<ModuleEngines> GetAllEngines(Vessel vessel)
     {
       List<ModuleEngines> engines = new List<ModuleEngines>();

--- a/KSP/MainWindow.cs
+++ b/KSP/MainWindow.cs
@@ -25,9 +25,9 @@ namespace BoosterGuidance
     int tab = 0;
     bool hidden = true;
     BoosterGuidanceCore core = null;
-    float maxReentryGain = 3;
-    float maxAeroDescentGain = 3;
-    float maxLandingBurnGain = 3;
+    float maxReentryGain = 1;
+    float maxAeroDescentGain = 1;
+    float maxLandingBurnGain = 1;
     float maxSteerAngle = 30; // 30 degrees
     Rect windowRect = new Rect(150, 150, 220, 520);
 
@@ -39,8 +39,6 @@ namespace BoosterGuidance
     EditableInt tgtAlt = 0;
     EditableInt reentryBurnAlt = 55000;
     EditableInt reentryBurnTargetSpeed = 700;
-    //float aeroDescentSteerLogKp = 5.5f;
-    //float landingBurnSteerLogKp = 2.5f;
     string numLandingBurnEngines = "current";
 
     // Advanced GUI Elements
@@ -65,7 +63,6 @@ namespace BoosterGuidance
 
     public void Start()
     {
-      Debug.Log("[BoosterGuidance] Start");
       hasFAR = Trajectories.AerodynamicModelFactory.HasFAR();
       Debug.Log("[BoosterGuidance] Start hasFAR="+hasFAR);
     }
@@ -78,7 +75,6 @@ namespace BoosterGuidance
 
     public void OnDestroy()
     {
-      Debug.Log("[BoosterGuidance] Destroy");
       hidden = true;
       Targets.targetingCross.enabled = false;
       Targets.predictedCross.enabled = false;
@@ -90,8 +86,15 @@ namespace BoosterGuidance
       {
         Debug.Log("[BoosterGuidance] core==null vessel=" + vessel + " map=" + MapView.MapIsEnabled);
         core = BoosterGuidanceCore.GetBoosterGuidanceCore(vessel);
-        UpdateFromCore();
-        Targets.SetVisibility(showTargets, showTargets && core.Enabled() && (FlightGlobals.ActiveVessel == core.vessel));
+        if (core != null)
+        {
+          UpdateFromCore();
+          Targets.SetVisibility(showTargets, showTargets && core.Enabled() && (FlightGlobals.ActiveVessel == core.vessel));
+        }
+        else
+        {
+          return core;
+        }
       }
       else
       {

--- a/KSP/MainWindow.cs
+++ b/KSP/MainWindow.cs
@@ -50,6 +50,7 @@ namespace BoosterGuidance
     bool deployLandingGear = true;
     EditableInt deployLandingGearHeight = 500;
     EditableInt igniteDelay = 3; // Needed for RO
+    double aeroMult = 1;
 
     // Targeting
     ITargetable lastVesselTarget = null;
@@ -256,6 +257,13 @@ namespace BoosterGuidance
       GUILayout.EndHorizontal();
 
       GUILayout.BeginHorizontal();
+      GUILayout.Label("Aero multiplier");
+      core.aeroMult = GUILayout.HorizontalSlider(core.aeroMult, 1, 5);
+      GUILayout.Label(string.Format("{0:F1}",core.aeroMult.ToString()));
+      GUILayout.EndHorizontal();
+
+
+      GUILayout.BeginHorizontal();
       debug = GUILayout.Toggle(debug, "Debug");
       Targets.showSteer = debug;
       GUILayout.EndHorizontal();
@@ -458,9 +466,7 @@ namespace BoosterGuidance
       else
       {
         if (GUILayout.Button("Unset"))  // Set to currently active engines
-        {
           numLandingBurnEngines = core.UnsetLandingBurnEngines();
-        }
       }
       GUILayout.EndHorizontal();
 
@@ -468,7 +474,6 @@ namespace BoosterGuidance
       GUILayout.Label("Steer", GUILayout.Width(40));
       core.landingBurnSteerKp = Mathf.Clamp(core.landingBurnSteerKp, 0, maxLandingBurnGain);
       core.landingBurnSteerKp = GUILayout.HorizontalSlider(core.landingBurnSteerKp, 0, maxLandingBurnGain);
-      //core.landingBurnSteerKp = Mathf.Exp(landingBurnSteerLogKp);
       GUILayout.Label(((int)(core.landingBurnMaxAoA)).ToString() + "°(max)", GUILayout.Width(60));
       GUILayout.EndHorizontal();
 

--- a/KSP/MainWindow.cs
+++ b/KSP/MainWindow.cs
@@ -25,9 +25,9 @@ namespace BoosterGuidance
     int tab = 0;
     bool hidden = true;
     BoosterGuidanceCore core = null;
-    float maxReentryGain = 0.001f;
-    float maxAeroDescentGain = 0.002f;
-    float maxLandingBurnGain = 0.002f;
+    float maxReentryGain = 3;
+    float maxAeroDescentGain = 3;
+    float maxLandingBurnGain = 3;
     float maxSteerAngle = 30; // 30 degrees
     Rect windowRect = new Rect(150, 150, 220, 520);
 
@@ -466,6 +466,7 @@ namespace BoosterGuidance
       GUILayout.Label("Steer", GUILayout.Width(40));
       core.landingBurnSteerKp = Mathf.Clamp(core.landingBurnSteerKp, 0, maxLandingBurnGain);
       core.landingBurnSteerKp = GUILayout.HorizontalSlider(core.landingBurnSteerKp, 0, maxLandingBurnGain);
+      //Debug.Log("[BoosterGuidance] Slider kp=" + core.landingBurnSteerKp + " maxLandingBurnGain=" + maxLandingBurnGain);
       GUILayout.Label(((int)(core.landingBurnMaxAoA)).ToString() + "°(max)", GUILayout.Width(60));
       GUILayout.EndHorizontal();
 

--- a/KSP/MainWindow.cs
+++ b/KSP/MainWindow.cs
@@ -50,7 +50,6 @@ namespace BoosterGuidance
     bool deployLandingGear = true;
     EditableInt deployLandingGearHeight = 500;
     EditableInt igniteDelay = 3; // Needed for RO
-    double aeroMult = 1;
 
     // Targeting
     ITargetable lastVesselTarget = null;
@@ -255,13 +254,6 @@ namespace BoosterGuidance
       GUILayout.BeginHorizontal();
       GuiUtils.SimpleTextBox("Engine startup", igniteDelay, "s", 65);
       GUILayout.EndHorizontal();
-
-      GUILayout.BeginHorizontal();
-      GUILayout.Label("Aero mult");
-      core.aeroMult = GUILayout.HorizontalSlider(core.aeroMult, 1, 5);
-      GUILayout.Label(((int)core.aeroMult).ToString(), GUILayout.Width(15));
-      GUILayout.EndHorizontal();
-
 
       GUILayout.BeginHorizontal();
       debug = GUILayout.Toggle(debug, "Debug");

--- a/KSP/MainWindow.cs
+++ b/KSP/MainWindow.cs
@@ -257,9 +257,9 @@ namespace BoosterGuidance
       GUILayout.EndHorizontal();
 
       GUILayout.BeginHorizontal();
-      GUILayout.Label("Aero multiplier");
+      GUILayout.Label("Aero mult");
       core.aeroMult = GUILayout.HorizontalSlider(core.aeroMult, 1, 5);
-      GUILayout.Label(string.Format("{0:F1}",core.aeroMult.ToString()));
+      GUILayout.Label(((int)core.aeroMult).ToString(), GUILayout.Width(15));
       GUILayout.EndHorizontal();
 
 

--- a/KSP/Targets.cs
+++ b/KSP/Targets.cs
@@ -269,11 +269,13 @@ namespace BoosterGuidance
 
     public static void RedrawTarget(CelestialBody body, double lat, double lon, double alt)
     {
+      InitTargets();
       targetingCross.SetLatLonAlt(body, lat, lon, alt);
     }
 
     public static void RedrawPrediction(CelestialBody body, double lat, double lon, double alt)
     {
+      InitTargets();
       predictedCross.SetLatLonAlt(body, lat, lon, alt);
     }
   }

--- a/KSP/Trajectories/AeroDynamicModelFactory.cs
+++ b/KSP/Trajectories/AeroDynamicModelFactory.cs
@@ -32,7 +32,7 @@ namespace Trajectories
       }
       catch (Exception e)
       {
-        Debug.Log("[BoosterGuidance] Checking for FAR: " + e.ToString());
+        Debug.Log("[BoosterGuidance] Checking for FAR - failed(" + e.ToString()+")");
         return false;
       }
       Debug.Log("[BoosterGuidance] Checking for FAR - success!");

--- a/KSP/Trajectories/FARModel.cs
+++ b/KSP/Trajectories/FARModel.cs
@@ -37,15 +37,11 @@ namespace Trajectories
 
     class FARModel: VesselAerodynamicModel
     {
-        //private MethodInfo FARAPI_CalculateVesselAeroForces;
-
         public override string AerodynamicModelName { get { return "FAR"; } }
 
-         //public FARModel(Vessel ship, CelestialBody body, MethodInfo CalculateVesselAeroForces)
          public FARModel(Vessel ship, CelestialBody body)
          : base(ship, body)
         {
-          //FerramAerospaceResearch.FARAPI.CalculateVesselAeroForces(ship, out Vector3 res_drag, out Vector3 torque, Vector3d.zero, 100000);
         }
 
         protected override Vector3d ComputeForces_Model(Vector3d airVelocity, double altitude)
@@ -55,13 +51,10 @@ namespace Trajectories
 
             if (airVelocity.x == 0d || airVelocity.y == 0d || airVelocity.z == 0d)
             {
-                //Debug.LogWarning(string.Format("Trajectories: Getting FAR forces - Velocity: {0} | Altitude: {1}", airVelocity, altitude));
                 return Vector3.zero;
             }
 
             Vector3 worldAirVel = new Vector3((float)airVelocity.x, (float)airVelocity.y, (float)airVelocity.z);
-            //var parameters = new object[] { vessel_, new Vector3(), new Vector3(), worldAirVel, altitude };
-            //FARAPI_CalculateVesselAeroForces.Invoke(null, parameters);
 
             // Force direct call of API. Why not?
             FerramAerospaceResearch.FARAPI.CalculateVesselAeroForces(vessel_, out Vector3 res_drag, out Vector3 torque, worldAirVel, altitude);

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ KSP=/Users/${USER}/Library/Application\ Support/Steam/steamapps/common/Kerbal\ S
 # Additional install locations
 KSP_CUTDOWN=~/KSP_Cutdown
 KSP_RO=~/KSP_RO
-VER=v1.0.4
+VER=v1.1.0
 GAMEDATADEPS=GameData/BoosterGuidance/BoosterGuidance.cfg
 
 .PHONY: all install

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.4.0")]
-[assembly: AssemblyFileVersion("1.0.4.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/TODO
+++ b/TODO
@@ -6,14 +6,9 @@
 - Prediction target shifts and jumps sometimes on Mun. Possibly only on timewarp and fixed?
 - Keep thrust high for re-entry when velocity means predicted impact is moving fast away from us (activate from orbit)
 - sometimes problem with sharing violation on logging when enable/disable guidance
-- sometimes massive prediction target shows
-- Both targets sometimes too big. Odd because size is calculated every frame they are drawn
 - Add info message which give hints about settings: touchdown margin, no steer height and touchdown speed
 - Compute distance from ground wherever you are landing
-- Failure to show AdvancedTab as NullReference to previous controller? possibly fixed
-- Lots of BoosterGuidanceCore.OnDestroy() exceptions with reference to non-instance (BLController). Why?
-- Landing Burn steer direction wrong for large test craft. Things aerodynamics dominates but it doesn't
-- Is setting the landing burn engines working correctly?
 - Messages when switching phase and reason why
 - Tool tips
 - Language translations
+- Add Guidance Toggle as action group

--- a/TODO
+++ b/TODO
@@ -14,3 +14,6 @@
 - Lots of BoosterGuidanceCore.OnDestroy() exceptions with reference to non-instance (BLController). Why?
 - Landing Burn steer direction wrong for large test craft. Things aerodynamics dominates but it doesn't
 - Is setting the landing burn engines working correctly?
+- Messages when switching phase and reason why
+- Tool tips
+- Language translations

--- a/TODO
+++ b/TODO
@@ -12,3 +12,5 @@
 - Compute distance from ground wherever you are landing
 - Failure to show AdvancedTab as NullReference to previous controller? possibly fixed
 - Lots of BoosterGuidanceCore.OnDestroy() exceptions with reference to non-instance (BLController). Why?
+- Landing Burn steer direction wrong for large test craft. Things aerodynamics dominates but it doesn't
+- Is setting the landing burn engines working correctly?

--- a/TODO
+++ b/TODO
@@ -7,10 +7,8 @@
 - Keep thrust high for re-entry when velocity means predicted impact is moving fast away from us (activate from orbit)
 - sometimes problem with sharing violation on logging when enable/disable guidance
 - sometimes massive prediction target shows
-- Both targets sometimes too big. Force redraw?
+- Both targets sometimes too big. Odd because size is calculated every frame they are drawn
 - Add info message which give hints about settings: touchdown margin, no steer height and touchdown speed
 - Compute distance from ground wherever you are landing
 - Failure to show AdvancedTab as NullReference to previous controller? possibly fixed
 - Lots of BoosterGuidanceCore.OnDestroy() exceptions with reference to non-instance (BLController). Why?
-- Show target error in km when large to avoid wrapping line. Perhaps to nearest km when over 100km?
-- Gains can be well out of range when loading saved game, and on loaded just built vessel


### PR DESCRIPTION
Fixed setting landing burn engines
Large bug fix in aero force calculation (we using r rather than r-mainBody.position)
So aero calculation was actually badly wrong previous
Now use calculated gain given balance for Faero vs Fthrust
This still seems to under-estimate Faero as steers wrong way in landing thrust for some vessel. Compensate by upping Faero by factor of 2
Don't steer when Faero and Fthrust are close. The current factor is when one is >30% of other. Gain is set to zero
This should mean its not necessary to reduce gains to almost nothing for RO, but its best to still set them quite low
I also observed the steer direction in re-entry burn was wrong sometimes where Faero should be tiny at 55km+
Hopefully this means steer direction should be better in landing burn mainly for some vessels
Enable/Disable guidance is an Action Group (actually done in v1.0.4)