### PR TITLE
Tuning of gains and simulation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,13 @@
+v1.1.1
+- Upped throttle gains which avoids very heavy vessels hitting ground (depends on dt in simulate)
+- Targets cross updates when selecting vessel or navigation target
+- Landing burn works correctly when clicking button even if aero-descent not enabled first
+- Fixed bug in simulate that led to landing burn not being simulated below 500m (leading to jitter in predictions)
+- Tuning of simulation to make it as fast and accurately as I currently can
+- Now runs faster for planets with no atmosphere
+- Reduced maximum gains to try and reduce the near to tweak gains to reduce max angle-of-attack in RO (gains still needed to be low for RO)
+- Reduced jitter to landing prediction by reducing timestep of simulation when near ground
+
 v1.1.0
 - Finally fixed steer gain calculation (perhaps) as several bugs discovered
 - Added action group to toggle guidance

--- a/Core/BLController.cs
+++ b/Core/BLController.cs
@@ -217,8 +217,8 @@ namespace BoosterGuidance
       String name = PhaseStr().Replace(" ", "_");
       Vector3d tgt_r = vessel.mainBody.GetWorldSurfacePosition(tgtLatitude, tgtLongitude, tgtAlt);
       BLController tc = new BLController(this);
-      Simulate.ToGroundVariableStep(tgtAlt, vessel, aeroModel, vessel.mainBody, tc, tgt_r, out targetT, logFilename + ".Simulate." + name + ".dat", logTransform, vessel.missionTime - logStartTime);
-      Simulate.ToGroundVariableStep(tgtAlt, vessel, aeroModel, vessel.mainBody, null, tgt_r, out targetT, logFilename + ".Simulate.Free.dat", logTransform, vessel.missionTime - logStartTime);
+      Simulate.ToGround(tgtAlt, vessel, aeroModel, vessel.mainBody, tc, tgt_r, out targetT, logFilename + ".Simulate." + name + ".dat", logTransform, vessel.missionTime - logStartTime);
+      Simulate.ToGround(tgtAlt, vessel, aeroModel, vessel.mainBody, null, tgt_r, out targetT, logFilename + ".Simulate.Free.dat", logTransform, vessel.missionTime - logStartTime);
     }
 
 
@@ -357,7 +357,7 @@ namespace BoosterGuidance
         // the remaining phases and doesn't try to redo reentry burn for instance
         if (phase == BLControllerPhase.BoostBack)
           tc.phase = BLControllerPhase.Coasting;
-        predWorldPos = Simulate.ToGroundVariableStep(tgtAlt, vessel, aeroModel, body, tc, tgt_r, out targetT);
+        predWorldPos = Simulate.ToGround(tgtAlt, vessel, aeroModel, body, tc, tgt_r, out targetT);
         landingBurnAMax = tc.landingBurnAMax;
         landingBurnHeight = tc.landingBurnHeight; // Update from simulation
         tgt_r = body.GetWorldSurfacePosition(tgtLatitude, tgtLongitude, tgtAlt);

--- a/Core/BLController.cs
+++ b/Core/BLController.cs
@@ -70,8 +70,6 @@ namespace BoosterGuidance
 
     // Cache previous values - only calculate new at log interval
     private double lastt = 0;
-    private double lastThrottle = 0;
-    private Vector3d lastSteer = Vector3d.zero;
     private Vector3d last_vel_air = Vector3d.zero;
 
     public BLController()
@@ -219,8 +217,8 @@ namespace BoosterGuidance
       String name = PhaseStr().Replace(" ", "_");
       Vector3d tgt_r = vessel.mainBody.GetWorldSurfacePosition(tgtLatitude, tgtLongitude, tgtAlt);
       BLController tc = new BLController(this);
-      Simulate.ToGround(tgtAlt, vessel, aeroModel, vessel.mainBody, tc, tgt_r, out targetT, logFilename + ".Simulate." + name + ".dat", logTransform, vessel.missionTime - logStartTime);
-      Simulate.ToGround(tgtAlt, vessel, aeroModel, vessel.mainBody, null, tgt_r, out targetT, logFilename + ".Simulate.Free.dat", logTransform, vessel.missionTime - logStartTime);
+      Simulate.ToGroundVariableStep(tgtAlt, vessel, aeroModel, vessel.mainBody, tc, tgt_r, out targetT, logFilename + ".Simulate." + name + ".dat", logTransform, vessel.missionTime - logStartTime);
+      Simulate.ToGroundVariableStep(tgtAlt, vessel, aeroModel, vessel.mainBody, null, tgt_r, out targetT, logFilename + ".Simulate.Free.dat", logTransform, vessel.missionTime - logStartTime);
     }
 
 
@@ -310,7 +308,8 @@ namespace BoosterGuidance
                     bool simulate, // if true just go retrograde (no corrections)
                     out double throttle, out Vector3d steer,
                     out bool landingGear, // true if landing gear requested (stays true)
-                    bool bailOutLandingBurn = false) // if set too true on RO set throttle=0 if thrust > gravity at landing
+                    bool bailOutLandingBurn = false, // if set too true on RO set throttle=0 if thrust > gravity at landing
+                    bool showCpuTime = false)
 
     {
       // height of lowest point with additional margin
@@ -318,7 +317,6 @@ namespace BoosterGuidance
       Vector3d up = Vector3d.Normalize(r - body.position);
       Vector3d vel_air = v - body.getRFrmVel(r);
       double vy = Vector3d.Dot(vel_air, up); // TODO - Or vel_air?
-      double throttleGain = 0;
       double amin = minThrust / totalMass;
       double amax = maxThrust / totalMass;
       float minThrottle = 0.01f;
@@ -328,19 +326,23 @@ namespace BoosterGuidance
       timer.Start();
       string msg = ""; // return message about the status
 
-      steer = lastSteer;
-      throttle = lastThrottle;
       landingGear = (y < deployLandingGearHeight) && (deployLandingGear);
 
       double g = FlightGlobals.getGeeForceAtPosition(r).magnitude;
-
-      if (amax > 0) // check in case out of fuel or something
-        throttleGain = 5 / (amax - amin); // cancel velocity over 1.25 seconds
+      double dt = t - lastt;
 
       // We will compute thrust and steer at the maximum rate when y<500
-      // and not being run for a simulate (which would be slower)
-      if ((t < lastt + 1.0/Math.Max(simulationsPerSec,0.1)) && (y>500) || (simulate))
-        return msg;
+      // and not being run for a simulation (which would be slower)
+      // simulate will regulate calling this function as only calls in dt timestep, never return the
+      // last throttle, steer since this messes with winding back the integration step
+      /*
+      if (!simulate)
+      {
+        // Only run a simulationsPerSec unless very near ground
+        if ((dt >= 1.0 / simulationsPerSec) && (y > 500))
+          return msg;
+      }
+      */
 
       // No thrust - retrograde relative to surface (default and Coasting phase
       throttle = 0;
@@ -355,7 +357,8 @@ namespace BoosterGuidance
         // the remaining phases and doesn't try to redo reentry burn for instance
         if (phase == BLControllerPhase.BoostBack)
           tc.phase = BLControllerPhase.Coasting;
-        predWorldPos = Simulate.ToGround(tgtAlt, vessel, aeroModel, body, tc, tgt_r, out targetT);
+        predWorldPos = Simulate.ToGroundVariableStep(tgtAlt, vessel, aeroModel, body, tc, tgt_r, out targetT);
+        landingBurnAMax = tc.landingBurnAMax;
         landingBurnHeight = tc.landingBurnHeight; // Update from simulation
         tgt_r = body.GetWorldSurfacePosition(tgtLatitude, tgtLongitude, tgtAlt);
         error = predWorldPos - tgt_r;
@@ -414,7 +417,9 @@ namespace BoosterGuidance
         if (errv > 0)
         {
           double newThrottle = HGUtils.LinearMap((double)y, (double)reentryBurnAlt, (double)reentryBurnAlt - 8000, 0.1, 1);
-          double da = g + Math.Max(errv * 0.4, 10); // attempt to cancel 40% of extra velocity in 1 second and min of 10m/s/s
+          // Limit maximum de-acceleration to make the simulation accuract when dt=2 or 4 secs
+          double da = g + Math.Min(0.5*Math.Max(errv * 0.4, 10)/dt,50); // attempt to cancel 40% of extra velocity in 2*dt and min of 10m/s/s
+          // Use of dt prevents too high throttle when simulating re-entry burn with dt=2 or 4 secs.
           newThrottle = (da - amin) / (0.01 + amax - amin);
           throttle = HGUtils.Clamp(newThrottle, minThrottle, 1);
         }
@@ -440,10 +445,13 @@ namespace BoosterGuidance
       // AERO DESCENT
       if (phase == BLControllerPhase.AeroDescent)
       {
-        pid_aero.kp = aeroDescentSteerKp * CalculateSteerGain(0, vel_air, r, y, totalMass, false);
-        steerGain = pid_aero.kp;
-        double ang = pid_aero.Update(error.magnitude, Time.deltaTime);
-        steer = -Vector3d.Normalize(vel_air) + GetSteerAdjust(error, ang, aeroDescentMaxAoA);
+        if (!simulate)
+        {
+          pid_aero.kp = aeroDescentSteerKp * CalculateSteerGain(0, vel_air, r, y, totalMass, false);
+          steerGain = pid_aero.kp;
+          double ang = pid_aero.Update(error.magnitude, dt);
+          steer = -Vector3d.Normalize(vel_air) + GetSteerAdjust(error, ang, aeroDescentMaxAoA);
+        }
 
         double landingMinThrust, landingMaxThrust;
         KSPUtils.ComputeMinMaxThrust(vessel, out landingMinThrust, out landingMaxThrust, false, landingBurnEngines);
@@ -452,8 +460,9 @@ namespace BoosterGuidance
         if (Math.Abs(landingBurnAMax - newLandingBurnAMax) > 0.02)
         {
           landingBurnAMax = landingMaxThrust / totalMass; // update so we don't continually recalc
-          landingBurnHeight = Simulate.CalculateLandingBurnHeight(tgtAlt, r, v, vessel, totalMass, landingMinThrust, landingMaxThrust, aeroModel, vessel.mainBody, this, 100, "landing_burn.dat");
+          landingBurnHeight = Simulate.CalculateLandingBurnHeight(tgtAlt, r, v, vessel, totalMass, landingMinThrust, landingMaxThrust, aeroModel, vessel.mainBody, this, 100);
         }
+
         if (y - vel_air.magnitude * igniteDelay <= landingBurnHeight) // Switch to landing burn N secs earlier to allow RO engine start up time
         {
           lowestY = KSPUtils.FindLowestPointOnVessel(vessel);
@@ -473,13 +482,14 @@ namespace BoosterGuidance
           msg = string.Format(Localizer.Format("#BoosterGuidance_SetXEnginesForLanding", landingBurnEngines.Count.ToString()));
           setLandingEnginesDone = true;
         }
-        av = Math.Max(0.1, landingBurnAMax - g); // wrong on first iteration
+        av = Math.Max(0.1, maxThrust/totalMass - g); // wrong on first iteration
         if (y > 0)
           dvy = -Math.Sqrt((1 + suicideFactor) * av * y) - touchdownSpeed; // Factor is 2 for perfect suicide burn, lower for margin and hor vel
         if (amax > 0)
         {
           double err_dv = vy - dvy; // +ve is velocity too high
-          double da = g - (5 * err_dv); // required accel to change vy, cancel out g (only works if vertical)
+          double da = g - (err_dv/dt); // required accel to change vy in next two timesteps, cancel out g (only works if vertical)
+          
           throttle = HGUtils.Clamp((da - amin) / (0.01 + amax - amin), minThrottle, 1);
           // compensate if not vertical as need more vertical component of thrust
           throttle = HGUtils.Clamp(throttle / Math.Max(0.1, Vector3.Dot(att, up)), minThrottle, 1);
@@ -534,7 +544,6 @@ namespace BoosterGuidance
         Vector3d ta = logTransform.InverseTransformVector(a);
         fp.WriteLine("{0:F1} {1} {2:F1} {3:F1} {4:F1} {5:F1} {6:F1} {7:F1} {8:F1} {9:F1} {10:F1} {11:F1} {12:F1} {13:F1} {14:F3} {15:F1} {16:F2}", t - logStartTime, phase, tr.x, tr.y, tr.z, tv.x, tv.y, tv.z, a.x, a.y, a.z, attitudeError, amin, amax, steerGain, targetError, totalMass);
         logLastTime = t;
-        last_vel_air = vel_air;
       }
 
       lastt = t;
@@ -547,10 +556,6 @@ namespace BoosterGuidance
       // So the logging is done at the start of the new phase
       if ((lastPhase != phase) && (fp != null))
         LogSimulation();
-
-      // Cache
-      lastSteer = steer;
-      lastThrottle = throttle;
 
       elapsed_secs = timer.ElapsedMilliseconds * 0.001;
 
@@ -578,7 +583,10 @@ namespace BoosterGuidance
         string s2 = string.Format("{0:F0}", attitudeError);
         string s3 = string.Format("{0:F0}", targetT);
         string s4 = string.Format("{0:F0}", elapsed_secs * 1000);
-        info = string.Format(Localizer.Format("#BoosterGuidance_ErrorXTimeXCPUX", s1, s2, s3, s4));
+        if (showCpuTime)
+          info = string.Format(Localizer.Format("#BoosterGuidance_ErrorXTimeXCPUX", s1, s2, s3, s4));
+        else
+          info = string.Format(Localizer.Format("#BoosterGuidance_ErrorXTimeX", s1, s2, s3));
       }
 
       if (msg != "")

--- a/Core/Controller.cs
+++ b/Core/Controller.cs
@@ -38,7 +38,8 @@ namespace BoosterGuidance
                bool simulate,
                out double throttle, out Vector3d steer,
                out bool landingGear,
-               bool bailOutLandingBurn = false)
+               bool bailOutLandingBurn = false,
+               bool showCpuTime = false)
 
     {
       throttle = 0;

--- a/Core/Simulate.cs
+++ b/Core/Simulate.cs
@@ -62,13 +62,13 @@ namespace BoosterGuidance
       Vector3d F = aeroModel.GetForces(body, r, vel_air, Math.PI) * aeroFudgeFactor + Ft;
       Vector3d a = F / totalMass + g;
 
-      out_r = r + v * dt;
+      out_r = r + v * dt + 0.5 * a * dt * dt;
       out_v = v + a * dt;
     }
 
 
     static private Vector3d GetForces(Vessel vessel, Vector3d r, Vector3d v, Vector3d att, double totalMass, double minThrust, double maxThrust,
-      Trajectories.VesselAerodynamicModel aeroModel, CelestialBody body, double t,
+      Trajectories.VesselAerodynamicModel aeroModel, CelestialBody body, double t, double dt,
       BLController controller, Vector3d tgt_r, double aeroFudgeFactor,
       out Vector3d steer, out Vector3d vel_air, out double throttle)
     {
@@ -104,7 +104,7 @@ namespace BoosterGuidance
       return F;
     }
 
-
+    /*
     static public Vector3d ToGround(double tgtAlt, Vessel vessel, Trajectories.VesselAerodynamicModel aeroModel, CelestialBody body, BLController controller,
       Vector3d tgt_r, out double T, string logFilename="", Transform logTransform=null, double timeOffset=0, double maxT=600)
       // logTransform is transform at the current time
@@ -115,7 +115,7 @@ namespace BoosterGuidance
       if (logFilename != "")
       {
         f = new System.IO.StreamWriter(logFilename);
-        f.WriteLine("time x y z vx vy vz ax ay az att_err airspeed target_error total_mass");
+        f.WriteLine("time x y z vx vy vz ax ay az att_err target_error total_mass");
         f.WriteLine("# tgtAlt=" + tgtAlt);
       }
 
@@ -140,13 +140,16 @@ namespace BoosterGuidance
         targetError = controller.targetError;
       }
 
-      double dt = 2; // above atmosphere
-      if (y < 70000)
-        dt = 1;
+      double dt = 8; // above atmosphere
       double initialY = y;
+      
       while ((y > tgtAlt) && (T < maxT))
       {
         y = r.magnitude - body.Radius;
+        if (y < 60000) // TODO: change for different planets
+          dt = 1;
+        //if (y < 10000)
+        //  dt = 0.5;
         // Get all forces, i.e. aero-dynamic and thrust
         Vector3d vel_air;
         Vector3d steer;
@@ -156,9 +159,9 @@ namespace BoosterGuidance
         Vector3d out_v;
         EulerStep(dt, vessel, r, v, att, totalMass, minThrust, maxThrust, aeroModel, body, T, controller, tgt_r, aeroFudgeFactor, out steer, out vel_air, out throttle, out out_r, out out_v);
         r = out_r;
+        lastv = v;
         v = out_v;
         att = steer; // assume can turn immediately
-
         if (f != null)
         {
           // NOTE: Cancel out rotation of planet
@@ -175,13 +178,14 @@ namespace BoosterGuidance
           tr = logTransform.InverseTransformPoint(tr + body.position);
           Vector3d tv = logTransform.InverseTransformVector(tr2 - tr1);
           ta = logTransform.InverseTransformVector(ta);
-          f.WriteLine(string.Format("{0} {1:F5} {2:F5} {3:F5} {4:F5} {5:F5} {6:F5} {7:F1} {8:F1} {9:F1} 0 {10:F1} {11:F2} {12:F2}", T + timeOffset, tr.x, tr.y, tr.z, tv.x, tv.y, tv.z, ta.x, ta.y, ta.z, vel_air.magnitude, targetError, totalMass));
+          f.WriteLine(string.Format("{0} {1:F5} {2:F5} {3:F5} {4:F5} {5:F5} {6:F5} {7:F1} {8:F1} {9:F1} 0 {10:F2} {11:F2}", T + timeOffset, tr.x, tr.y, tr.z, tv.x, tv.y, tv.z, ta.x, ta.y, ta.z, targetError, totalMass));
         }
 
         T = T + dt;
       }
       if (T > maxT)
         Debug.Log("[BoosterGuidance] Simulation time exceeds maxT=" + maxT);
+
       // Correct to point of intersect on surface
       double vy = Vector3d.Dot(lastv, Vector3d.Normalize(r));
       double p = 0;
@@ -199,6 +203,150 @@ namespace BoosterGuidance
       ang = (float)((-T) * body.angularVelocity.magnitude / Math.PI * 180.0);
       bodyRotation = Quaternion.AngleAxis(ang, body.angularVelocity.normalized);
       r = bodyRotation * r ;
+      return r + body.position;
+    }
+    */
+
+    static public Vector3d ToGroundVariableStep(double tgtAlt, Vessel vessel, Trajectories.VesselAerodynamicModel aeroModel, CelestialBody body, BLController controller,
+      Vector3d tgt_r, out double T, string logFilename = "", Transform logTransform = null, double timeOffset = 0, double maxT = 600)
+    // Changes step size, dt, based on the amount of deacceleration forces, aero or thrust and winds back to choose smaller timesteps
+    {
+      float ang;
+      Quaternion bodyRotation;
+      System.IO.StreamWriter f = null;
+      if (logFilename != "")
+      {
+        f = new System.IO.StreamWriter(logFilename);
+        f.WriteLine("time x y z vx vy vz ax ay az att_err target_error total_mass");
+        f.WriteLine("# tgtAlt=" + tgtAlt);
+      }
+
+      T = 0;
+      Vector3d r = vessel.GetWorldPos3D() - body.position;
+      Vector3d v = vessel.GetObtVelocity();
+      Vector3d a = Vector3d.zero;
+      Vector3d last_r = r;
+      Vector3d last_v = v;
+      BLControllerPhase last_phase = controller.phase;
+      double minThrust, maxThrust;
+      double totalMass = vessel.totalMass;
+      // Initially thrust is for all operational engines
+      KSPUtils.ComputeMinMaxThrust(vessel, out minThrust, out maxThrust);
+      double y = r.magnitude - body.Radius;
+      // TODO: att should be supplied as vessel transform will be wrong in simulation
+      Vector3d att = new Vector3d(vessel.transform.up.x, vessel.transform.up.y, vessel.transform.up.z);
+      double targetError = 0;
+
+      if (controller != null)
+      {
+        // Take target error from previously calculated trajectory
+        // We would know this at the end but can't wait until then
+        targetError = controller.targetError;
+      }
+
+      double dt = 8; // above atmosphere
+      double last_T = T;
+
+      while ((y > tgtAlt) && (T < maxT))
+      {
+        if (f != null)
+        {
+          // NOTE: Cancel out rotation of planet
+          ang = (float)((-T) * body.angularVelocity.magnitude / Math.PI * 180.0);
+          // Rotation 1 second earlier
+          float prevang = (float)((-(T - 1)) * body.angularVelocity.magnitude / Math.PI * 180.0);
+          // Consider body rotation at this time
+          bodyRotation = Quaternion.AngleAxis(ang, body.angularVelocity.normalized);
+          Quaternion prevbodyRotation = Quaternion.AngleAxis(prevang, body.angularVelocity.normalized);
+          Vector3d tr = bodyRotation * r;
+          Vector3d tr1 = prevbodyRotation * r;
+          Vector3d tr2 = bodyRotation * (r + v);
+          Vector3d ta = bodyRotation * a;
+          tr = logTransform.InverseTransformPoint(tr + body.position);
+          Vector3d tv = logTransform.InverseTransformVector(tr2 - tr1);
+          ta = logTransform.InverseTransformVector(ta);
+          f.WriteLine(string.Format("{0} {1:F5} {2:F5} {3:F5} {4:F5} {5:F5} {6:F5} {7:F1} {8:F1} {9:F1} 0 {10:F2} {11:F2}", T + timeOffset, tr.x, tr.y, tr.z, tv.x, tv.y, tv.z, ta.x, ta.y, ta.z, targetError, totalMass));
+        }
+
+        y = r.magnitude - body.Radius;
+        if ((y < body.atmosphereDepth) || (y < controller.reentryBurnAlt + 1500*dt))
+          dt = 2;
+        Vector3d vel_air;
+        Vector3d steer;
+        double throttle;
+        double aeroFudgeFactor = 1.2; // Assume aero forces 20% higher which causes overshoot of target and more vertical final descent
+        Vector3d out_r;
+        Vector3d out_v;
+        // Compute time step change in r and v
+        EulerStep(dt, vessel, r, v, att, totalMass, minThrust, maxThrust, aeroModel, body, T, controller, tgt_r, aeroFudgeFactor, out steer, out vel_air, out throttle, out out_r, out out_v);
+
+        /*
+        if (throttle > 0.01)
+        {
+          if (dt > 1)
+          {
+            // wind back and recalculate
+            T = last_T;
+            r = last_r;
+            v = last_v;
+            // Repeat last time step with smaller dt
+            //Debug.Log("[BoosterGuidance] simulate repeating last time step");
+            // Reset controller?
+            controller.phase = last_phase;
+            dt = 1;
+            EulerStep(dt, vessel, r, v, att, totalMass, minThrust, maxThrust, aeroModel, body, T, controller, tgt_r, aeroFudgeFactor, out steer, out vel_air, out throttle, out out_r, out out_v);
+            r = out_r;
+            v = out_v;
+            T = T + dt;
+            // Now run this time step with smaller dt
+            EulerStep(dt, vessel, r, v, att, totalMass, minThrust, maxThrust, aeroModel, body, T, controller, tgt_r, aeroFudgeFactor, out steer, out vel_air, out throttle, out out_r, out out_v);
+          }
+          dt = 1; // keeps dt=1 when throttle is applied
+        }
+        else
+        {
+          dt = Math.Min(8, dt * 2); // raise dt again
+        }
+        */
+        
+        y = r.magnitude - body.Radius;
+        //Debug.Log("[BoosterGuidance] simulate y=" + y + " T=" + T + " dt=" + dt + " throttle="+throttle+" vel_air="+vel_air.magnitude);
+
+        att = steer; // assume can turn immediately
+        
+        last_phase = controller.phase;
+        last_r = r;
+        last_v = v;
+        last_T = T;
+        r = out_r;
+        v = out_v;
+
+        T = T + dt;
+      }
+      if (T > maxT)
+        Debug.Log("[BoosterGuidance] Simulation time exceeds maxT=" + maxT);
+
+      // Correct to point of intersect on surface
+      double vy = Vector3d.Dot(last_v, Vector3d.Normalize(r));
+      double p = 0;
+      if (vy < -0.1)
+      {
+        p = (tgtAlt - y) / -vy; // Backup proportion
+        r = r - last_v * p;
+        T = T - p;
+      }
+      if (f != null)
+        f.Close();
+
+      //Debug.Log("[BoosterGuidance] simulate() final_y=" + (r.magnitude - body.Radius)+" p="+p+" v(mag)="+lastv.magnitude+" vy="+vy);
+
+      //Debug.Log("[BoosterGuidance] simulate() final_y=" + (r.magnitude - body.Radius)+ " lastv(mag)="+lastv.magnitude);
+
+      // Compensate for body rotation giving world position in the surface point now
+      // that would be hit in the future
+      ang = (float)((-T) * body.angularVelocity.magnitude / Math.PI * 180.0);
+      bodyRotation = Quaternion.AngleAxis(ang, body.angularVelocity.normalized);
+      r = bodyRotation * r;
       return r + body.position;
     }
 
@@ -227,7 +375,7 @@ namespace BoosterGuidance
         f.WriteLine("time y vy dvy");
       }
 
-      double dt = 0.5;
+      double dt = 4; // was 0.5
       while ((y > tgtAlt) && (T < maxT))
       {
         y = r.magnitude - body.Radius;
@@ -238,12 +386,13 @@ namespace BoosterGuidance
         double aeroFudgeFactor = 1;
         // Need to simulate reentry burn to get reduced mass and less velocity
         // could probably approximation this well without much effort though
-        Vector3d F = GetForces(vessel, r, v, -Vector3d.Normalize(v), totalMass, minThrust, maxThrust, aeroModel, body, T, null, Vector3d.zero, aeroFudgeFactor, out steer, out vel_air, out throttle);
+        Vector3d F = GetForces(vessel, r, v, -Vector3d.Normalize(v), totalMass, minThrust, maxThrust, aeroModel, body, T, dt, null, Vector3d.zero, aeroFudgeFactor, out steer, out vel_air, out throttle);
 
         double R = r.magnitude;
         Vector3d g = r * (-body.gravParameter / (R * R * R));
 
         // Calculate suicide burn velocity
+        //Debug.Log("[BoosterGuidance g=" + g);
         double av = amax - g.magnitude;
         if (av < 0)
           av = 0.1; // pretend we have more thrust to look like we are doing something rather than giving up!!

--- a/Core/Simulate.cs
+++ b/Core/Simulate.cs
@@ -142,6 +142,8 @@ namespace BoosterGuidance
       }
 
       double dt = 8; // above atmosphere
+      if (y < 5000)
+        dt = 1;
       double last_T = T;
 
       while ((y > tgtAlt) && (T < maxT))
@@ -167,7 +169,8 @@ namespace BoosterGuidance
 
         y = r.magnitude - body.Radius;
         if ((y < body.atmosphereDepth) || (y < controller.reentryBurnAlt + 1500*dt))
-          dt = 2;
+          dt = Math.Min(dt,2);
+
         Vector3d vel_air;
         Vector3d steer;
         double throttle;

--- a/KSP/BoosterGuidanceCore.cs
+++ b/KSP/BoosterGuidanceCore.cs
@@ -100,6 +100,7 @@ namespace BoosterGuidance
 
     public void OnCrash()
     {
+      // TODO - does this work?
       if ((controller != null) && (controller.vessel = FlightGlobals.ActiveVessel) && (controller.enabled))
         GuiUtils.ScreenMessage("Vessel crashed - Try increasing touchdown margin in the advanced tab");
     }
@@ -298,8 +299,6 @@ namespace BoosterGuidance
         vessel.OnFlyByWire += new FlightInputCallback(Fly);
       }
       controller.SetPhase(BLControllerPhase.Unset);
-      // TODO - Shows wrong phase as phase isn't yet decidedd
-      //GuiUtils.ScreenMessage(Localizer.Format("#BoosterGuidance_Enabled") + " " + controller.PhaseStr());
       controller.enabled = true;
       AddController(controller);
     }

--- a/KSP/Localization/en-us.cfg
+++ b/KSP/Localization/en-us.cfg
@@ -47,5 +47,6 @@ Localization
         #BoosterGuidance_SetXEnginesForLanding = Set <<1>> engines for landing
         #BoosterGuidance_NoSteerHeightReached = No steering below steer height
         #BoosterGuidance_ErrorXTimeXCPUX = Err: <<1>> <<2>>° Time: <<3>>s [<<4>>ms]
+        #BoosterGuidance_ErrorXTimeX = Err: <<1>> <<2>>° Time: <<3>>s
     }
 }

--- a/KSP/Localization/en-us.cfg
+++ b/KSP/Localization/en-us.cfg
@@ -46,7 +46,7 @@ Localization
         #BoosterGuidance_LandedXFromTarget = Landed <<1>> from target
         #BoosterGuidance_SetXEnginesForLanding = Set <<1>> engines for landing
         #BoosterGuidance_NoSteerHeightReached = No steering below steer height
-        #BoosterGuidance_ErrorXTimeXCPUX = Err: <<1>> <<2>>° Time: <<3>>s [<<4>>ms]
-        #BoosterGuidance_ErrorXTimeX = Err: <<1>> <<2>>° Time: <<3>>s
+        #BoosterGuidance_ErrorXTimeXCPUX = Err <<1>> <<2>>° Time <<3>>s [<<4>>ms]
+        #BoosterGuidance_ErrorXTimeX = Err <<1>> <<2>>° Time <<3>>s
     }
 }

--- a/KSP/MainWindow.cs
+++ b/KSP/MainWindow.cs
@@ -162,8 +162,7 @@ namespace BoosterGuidance
           tgtLatitude = target.latitude;
           tgtLongitude = target.longitude;
           tgtAlt = (int)target.altitude;
-          core.SetTarget(tgtLatitude, tgtLongitude, tgtAlt);
-          core.Changed();
+          UpdateCore();
           string msg = String.Format(Localizer.Format("#BoosterGuidance_TargetSetToX"),target.name);
           GuiUtils.ScreenMessage(msg);
         }
@@ -190,9 +189,9 @@ namespace BoosterGuidance
           //tgtAlt = (int)nav.Altitude;
           tgtAlt = (int)FlightGlobals.ActiveVessel.mainBody.TerrainAltitude(tgtLatitude, tgtLongitude);
           core.SetTarget(tgtLatitude, tgtLongitude, tgtAlt);
-          core.Changed();
           string msg = String.Format(Localizer.Format("#BoosterGuidance_TargetSetToX"), pos.ToStringDMS());
           GuiUtils.ScreenMessage(msg);
+          UpdateCore();
         }
       }
       else
@@ -543,6 +542,7 @@ namespace BoosterGuidance
 
     public void UpdateCore()
     {
+      core.debug = debug;
       core.SetTarget(tgtLatitude, tgtLongitude, tgtAlt);
       // Set Angle - of - Attack from gains
       core.reentryBurnMaxAoA = maxSteerAngle * (core.reentryBurnSteerKp / maxReentryGain);
@@ -624,13 +624,18 @@ namespace BoosterGuidance
 
     void SetTargetHere()
     {
-      tgtLatitude = FlightGlobals.ActiveVessel.latitude;
-      tgtLongitude = FlightGlobals.ActiveVessel.longitude;
-      double lowestY = KSPUtils.FindLowestPointOnVessel(FlightGlobals.ActiveVessel);
-      tgtAlt = (int)FlightGlobals.ActiveVessel.altitude + (int)lowestY;
-      core.SetTarget(FlightGlobals.ActiveVessel.latitude, FlightGlobals.ActiveVessel.longitude, tgtAlt);
-      core.Changed();
-      GuiUtils.ScreenMessage(Localizer.Format("#BoosterGuidance_TargetSetToVessel"));
+      Vessel vessel = FlightGlobals.ActiveVessel;
+      if (vessel)
+      {
+        FlightGlobals.ActiveVessel.mainBody.GetLatLonAlt(vessel.GetWorldPos3D(), out double pickLat, out double pickLon, out double pickAlt);
+        double lowestY = KSPUtils.FindLowestPointOnVessel(FlightGlobals.ActiveVessel);
+        tgtLatitude = pickLat;
+        tgtLongitude = pickLon;
+        tgtAlt = (int)(pickAlt + lowestY);
+        core.SetTarget(tgtLatitude, tgtLongitude, tgtAlt);
+        core.Changed();
+        GuiUtils.ScreenMessage(Localizer.Format("#BoosterGuidance_TargetSetToVessel"));
+      }
     }
 
     void EnableGuidance(BLControllerPhase phase)

--- a/KSP/MainWindow.cs
+++ b/KSP/MainWindow.cs
@@ -25,9 +25,9 @@ namespace BoosterGuidance
     int tab = 0;
     bool hidden = true;
     BoosterGuidanceCore core = null;
-    float maxReentryGain = 1;
-    float maxAeroDescentGain = 1;
-    float maxLandingBurnGain = 0.5f;
+    float maxReentryGain = 0.5f;
+    float maxAeroDescentGain = 0.5f;
+    float maxLandingBurnGain = 0.25f;
     float maxSteerAngle = 30; // 30 degrees
     Rect windowRect = new Rect(150, 150, 220, 520);
 

--- a/KSP/MainWindow.cs
+++ b/KSP/MainWindow.cs
@@ -25,9 +25,9 @@ namespace BoosterGuidance
     int tab = 0;
     bool hidden = true;
     BoosterGuidanceCore core = null;
-    float maxReentryGain = 0.5f;
-    float maxAeroDescentGain = 0.5f;
-    float maxLandingBurnGain = 0.25f;
+    float maxReentryGain = 0.25f;
+    float maxAeroDescentGain = 0.2f;
+    float maxLandingBurnGain = 0.3f;
     float maxSteerAngle = 30; // 30 degrees
     Rect windowRect = new Rect(150, 150, 220, 520);
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ KSP=/Users/${USER}/Library/Application\ Support/Steam/steamapps/common/Kerbal\ S
 # Additional install locations
 KSP_CUTDOWN=~/KSP_Cutdown
 KSP_RO=~/KSP_RO
-VER=v1.1.0
+VER=v1.1.1
 GAMEDATADEPS=GameData/BoosterGuidance/BoosterGuidance.cfg
 
 .PHONY: all install
@@ -12,6 +12,7 @@ all: BoosterGuidance-${VER}.zip install
 
 BoosterGuidance-${VER}.zip: ./obj/Release/BoosterGuidance.dll ${GAMEDATADEPS}
 	cp $< GameData/BoosterGuidance
+	cp plot.py GameData/BoosterGuidance
 	cp LICENSE GameData/BoosterGuidance
 	cp README.md GameData/BoosterGuidance
 	cp CHANGES GameData/BoosterGuidance

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]

--- a/TODO
+++ b/TODO
@@ -7,3 +7,6 @@
 - sometimes problem with sharing violation on logging when enable/disable guidance
 - Compute distance from ground wherever you are landing
 - Tool tips
+- When on mun on aero descent predicted land spot drifts away and then returns to target every 1-2 secs sometimes between 0 to 800m error or similar. Why?
+- on time warp on Mun crash seems to jump location (I think)
+- report helpful message about crashing and upping touchdown margin?


### PR DESCRIPTION
Fixed altitude errors by doing it relative to origin rather than probe core. Touchdown margin can be less
Tweaked time steps for simulation to be faster and keep accuracy
Reduced maximum gains to less needs to tweak sliders to change max angle-of-attack
Uses planet atmosphere altitude to reduce tilmestep
Forward eqn. of motion not includes 0.5*a*dt*dt factor leading to better accuracy for timsteps of 4 or 8 secs out of atmosphere